### PR TITLE
Replace rindex(3) with strrchr(3)

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -393,7 +393,7 @@ char *make_lock_name ( char *ttydev )
     struct stat stat_buf;
 
     /* strip the leading path name */
-    ptr = rindex(ttydev, '/');
+    ptr = strrchr(ttydev, '/');
 
     devstr = dev_string;
     


### PR DESCRIPTION
This fixes compilation on Android, and should be a general improvement since `rindex(3)` is deprecated:
http://pubs.opengroup.org/onlinepubs/009695399/functions/rindex.html

The portability of `strrchr(3)` is fine and several common packages use it in their source code.

This patch has been used in the [Termux](https://termux.com/) heyu package.