### PR TITLE
Fix device and spool file locking

### DIFF
--- a/README
+++ b/README
@@ -225,6 +225,12 @@ LOCKDIR		LOCALSTATEDIR/lock; override with CPPFLAGS='...
 SPOOLDIR	LOCALSTATEDIR/tmp/heyu; override with CPPFLAGS='...
 		-DSPOOLDIR=\"path\" ...'
 
+Heyu uses HDB UUCP lock file format by default.  Binary lock file
+format can be requested if needed by calling ./configure with
+-DBINARY_LOCK_FILE_FORMAT option added to CPPFLAGS.  If using
+./Configure.sh, please edit the script so ./configure is called
+with that option.
+
 
 Default installation directories passed through ./configure to 'make
 install':

--- a/message.c
+++ b/message.c
@@ -26,6 +26,7 @@
  */
 
 #include <stdio.h>
+#include "process.h"
 #include "x10.h"
 
 char *E_2MANY = EM_2MANY;
@@ -35,6 +36,8 @@ char *E_NMA = EM_NMA;
 char *E_NOCMD = EM_NOCMD;
 
 void exit();
+
+extern CONFIG *configp;
 
 int usage(s)
 char *s;
@@ -91,8 +94,12 @@ char *s;
     extern int port_locked;
 
     (void) fprintf(stderr, "HEYU: %s\n", s);
-    if( port_locked == 1 )
-        munlock( "heyu.write" );
+    if( port_locked == 1 ) {
+        char writefilename[PATH_LEN + 1];
+
+        sprintf(writefilename, "%s%s", WRITEFILE, configp->suffix);
+        munlock(writefilename);
+    }
 
     quit();
 }

--- a/relay.c
+++ b/relay.c
@@ -194,7 +194,8 @@ int start_relay ( char *tty_name )
    strcat(spoolfile, spoolfilename);
 
    /* is a relay in place ? */
-    if ( lockpid(relayfilename) > (PID_T)1)  {
+    was_locked = lockpid(relayfilename);
+    if (was_locked && was_locked != getpid())  {
        if ( stat(spoolfile, &file_buf) < 0 )  {
 	   char tmpbuf[sizeof(spoolfile) + 100];
 	   sprintf(tmpbuf, "The file %s does not exist or is not writable.",
@@ -490,10 +491,9 @@ int start_relay ( char *tty_name )
 			  means a power failure*/
 
                     /* Set lock file if not already set */
-                    if ( (was_locked = lockpid(writefilename)) == (PID_T)0 ) {                    
-                        if ( lock_for_write() < 0 )
-                            error("Program exiting.\n");
-                    }
+                    was_locked = lockpid(writefilename);
+                    if (lock_for_write() < 0)
+                        error("Program exiting.\n");
                     port_locked = 1;
 
 		    powerfail = 0;

--- a/relay_aux.c
+++ b/relay_aux.c
@@ -317,7 +317,8 @@ int c_start_aux ( char *tty_auxname )
    strcat(spoolfile, spoolfilename);
 
    /* is an aux daemon in place ? */
-    if ( lockpid(auxfilename) > (PID_T)1)  {
+    was_locked = lockpid(auxfilename);
+    if (was_locked && was_locked != getpid()) {
        if ( verbose )
           printf("There was already an aux daemon running (pid = %ld)\n",
 		(long)lockpid(auxfilename) );

--- a/tty.c
+++ b/tty.c
@@ -312,12 +312,12 @@ int ttylock ( char *ttydev )
     devstr = make_lock_name(ttydev);
 
     if( verbose )
-        printf("Trying to lock (%s)\n", devstr);
-    rtn = lock_device(devstr);
+        printf("Trying to lock %s (%s)\n", ttydev, devstr);
+    rtn = lock_device(ttydev);
     if( (verbose) && ( rtn == 0 ) )
-            printf("%s is locked\n", devstr);
+            printf("%s is locked (%s)\n", ttydev, devstr);
     else if(  rtn != 0  )
-    	    printf("Unable to lock %s\n", devstr);
+	    printf("Unable to lock %s (%s)\n", ttydev, devstr);
 
     return(rtn);
 }
@@ -345,12 +345,13 @@ int munlock ( char *ttydev )
  */
 int lock_device ( char *ttydev )
 {
+    char *devstr, err_string[128], buf[12], *bufp;
     unsigned long our_pid = getpid(), lock_pid;
-    char err_string[128], buf[12], *bufp;
     int fd, count, ret;
 
+    devstr = make_lock_name(ttydev);
 retry:
-    fd = open(ttydev, O_EXCL | O_CREAT | O_RDWR, 0644);
+    fd = open(devstr, O_EXCL | O_CREAT | O_RDWR, 0644);
     if (fd >= 0) {
 #ifndef BINARY_LOCK_FILE_FORMAT
         snprintf(buf, sizeof(buf), "%10ld\n", our_pid);
@@ -377,7 +378,7 @@ retry:
 	}
 	close(fd);
 #ifdef REVERT_PERMS
-	chmod(ttydev, 0777);
+	chmod(devstr, 0777);
 #endif
 	millisleep(100);
 	goto retry;
@@ -387,7 +388,7 @@ retry:
 	    syslog(LOG_ERR,"Unable to create the lock file:");
 	syslog(LOG_DAEMON | LOG_ERR, "Unable to create the lock file.");
         /* error quits the program */
-        sprintf(err_string, "Unable to create the lock file %s.\n", ttydev);
+        sprintf(err_string, "Unable to create the lock file %s.\n", devstr);
         error(err_string);
     }
 


### PR DESCRIPTION
Refactor Heyu device and spool file locking code to follow recommendations
found in "Secure Programming Cookbook for C and C++" book by John Viega
and Matt Messier.

While being at it, allow using only one of lock file formats, HDF UUCP
(default) or binary, when reading form a lock file.  Support for reading
and also creating binary locks instead of the default HDP UCCP can be
selected at compile time if needed.  Reading PIDs with both methods while
creating only the HDF UUCP lock files seems incompatible with systems
and/or 3rd party applications which use binary format.  For lock files to
work correctly, all applications must use either the same format or both
formats in parallel when both creating and checking lock files.

Signed-off-by: Janusz Krzysztofik <jmkrzyszt@gmail.com>